### PR TITLE
Support on first page and refreshes

### DIFF
--- a/page-params/jqm.page.params.js
+++ b/page-params/jqm.page.params.js
@@ -71,6 +71,9 @@ function queryStringToObject( qstr )
 // The query params for the embedded page are also added as a property/value
 // object on the options object. You can access it from your page notifications
 // via data.options.pageData.
+
+var firstLoad = true;
+
 $( document ).bind( "pagebeforechange", function( e, data ) {
 
 	// We only want to handle the case where we are being asked
@@ -95,6 +98,13 @@ $( document ).bind( "pagebeforechange", function( e, data ) {
 				data.options.pageData = queryStringToObject( u2.search );
 				data.toPage = u.hrefNoHash + "#" + u2.pathname;
 			}
+		}
+	} else {
+		if (firstLoad) {
+			// First page load, so use a changePage to force through param passing magic"
+			firstLoad = false;
+			$.mobile.changePage(location.hash);
+			e.preventDefault();
 		}
 	}
 });


### PR DESCRIPTION
The previous implementation worked fine for loading an index.html and then using links or           $.mobile.changePage() to change pages.

However, it did not work when you refresh the page or if you start on a page with a parameterised hash address, such as #eventPage-123.

It now uses changePage on the first page load to force the correct behaviour.
